### PR TITLE
fix typo

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -71,7 +71,7 @@ exports.sourceNodes = ({ boundActionCreators, createNodeId }, configOptions) => 
               }
             : null,
           feature_image: {
-            url: post.feature_image,
+            url: post.featured_image,
             alt_text: post.featured_image_alt_text
           },
           meta: {

--- a/package.json
+++ b/package.json
@@ -16,5 +16,5 @@
     "node-fetch": "^2.2.0",
     "query-string": "^6.1.0"
   },
-  "version": "2.0.0"
+  "version": "2.0.1"
 }


### PR DESCRIPTION
Fixes #3 where a typo is breaking `feature_image` queries on the `url` property.