### PR TITLE
Remove boundActionCreators

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,8 +2,8 @@ const fetch = require('node-fetch')
 const queryString = require('query-string')
 const crypto = require('crypto')
 
-exports.sourceNodes = ({ boundActionCreators, createNodeId }, configOptions) => {
-  const { createNode } = boundActionCreators
+exports.sourceNodes = ({ actions, createNodeId, createContentDigest }, configOptions) => {
+  const { createNode } = actions
 
   delete configOptions.plugins
 

--- a/package.json
+++ b/package.json
@@ -16,5 +16,5 @@
     "node-fetch": "^2.2.0",
     "query-string": "^6.1.0"
   },
-  "version": "2.1.0"
+  "version": "2.2.0"
 }


### PR DESCRIPTION
https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/#removal-of-boundactioncreators

Since boundActionCreators has been removed this plugin is not compatible with GatsbyV3, this PR will fix that. 

Let me know if you have any questions thanks! 